### PR TITLE
Build architecture image with Github Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
+      with:
+        platforms: all
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to Docker Hub
@@ -22,5 +24,6 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: gcatanese/openapi-generator-postman-v2:latest


### PR DESCRIPTION
Small update to Github workflow to build image for both `linux/amd64` and `linux/arm64`