### PR TITLE
Deal with JSON values including commas

### DIFF
--- a/src/main/java/com/tweesky/cloudtools/codegen/ExampleJsonHelper.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/ExampleJsonHelper.java
@@ -7,8 +7,10 @@ import org.openapitools.codegen.CodegenProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Extract and format JSON examples
@@ -64,18 +66,21 @@ public class ExampleJsonHelper {
     }
 
     String formatJson(String json) {
-        String ret = json;
 
         // unescape double quotes already escaped
-        ret = ret.replace("\\\"", "\"");
+        json = json.replace("\\\"", "\"");
 
-        ret = ret.replace("{", "{" + JSON_ESCAPE_NEW_LINE + " ");
-        ret = ret.replace("}", JSON_ESCAPE_NEW_LINE + "}");
-        ret = ret.replace("\"", JSON_ESCAPE_DOUBLE_QUOTE);
-        ret = ret.replace(":", ": ");
-        ret = ret.replace(",", "," + JSON_ESCAPE_NEW_LINE + " ");
+        json = json.replace("{", "{" + JSON_ESCAPE_NEW_LINE + " ");
+        json = json.replace("}", JSON_ESCAPE_NEW_LINE + "}");
+        json = json.replace("\"", JSON_ESCAPE_DOUBLE_QUOTE);
+        json = json.replace(":", ": ");
 
-        return ret;
+        return Arrays.stream(getAttributes(json)).sequential().collect(Collectors.joining("," + JSON_ESCAPE_NEW_LINE + " "));
+    }
+
+    // array of attributes from JSON payload (ignore commas within quotes)
+    String[] getAttributes(String json) {
+        return json.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
     }
 
     String convertToJson(ObjectNode objectNode) {

--- a/src/test/java/com/tweesky/cloudtools/codegen/ExampleJsonHelperTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/ExampleJsonHelperTest.java
@@ -60,6 +60,24 @@ public class ExampleJsonHelperTest {
     }
 
     @Test
+    public void formatJsonIncludingCommas() {
+
+        final String EXPECTED = "{\\n \\\"id\\\": 1,\\n \\\"list\\\": \\\"AMS,LON,ROM\\\"\\n}";
+        final String JSON = "{\"id\":1,\"list\":\"AMS,LON,ROM\"}";
+
+        assertEquals(EXPECTED, new ExampleJsonHelper().formatJson(JSON));
+
+    }
+
+    @Test
+    public void getAttributesFromJson() {
+
+        final String JSON = "{\"id\":1,\"list\":\"AMS,LON,ROM\"}";
+        assertEquals(2, new ExampleJsonHelper().getAttributes(JSON).length);
+
+    }
+
+    @Test
     public void convertObjectNodeToJson() {
 
         final String EXPECTED = "{\\n \\\"id\\\": 1,\\n \\\"city\\\": \\\"Amsterdam\\\"\\n}";

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -376,4 +376,29 @@ public class PostmanV2GeneratorTest {
     assertEquals("any", new PostmanV2Generator().mapToPostmanType("object"));
   }
 
+  @Test
+  public void testJsonExampleIncludingValueWithCommas() throws IOException, ParseException {
+
+    File output = Files.createTempDirectory("postmantest_").toFile();
+    output.deleteOnExit();
+
+    final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("postman-v2")
+            .setInputSpec("./src/test/resources/JsonWithCommasInJsonExample.json")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+    final ClientOptInput clientOptInput = configurator.toClientOptInput();
+    DefaultGenerator generator = new DefaultGenerator();
+    List<File> files = generator.opts(clientOptInput).generate();
+
+    System.out.println(files);
+    files.forEach(File::deleteOnExit);
+
+    Path path = Paths.get(output + "/postman.json");
+    TestUtils.assertFileExists(path);
+    // check value with commas within quotes
+    TestUtils.assertFileContains(path, "\\\"acceptHeader\\\": \\\"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\\\"");
+  }
+
+
 }

--- a/src/test/resources/JsonWithCommasInJsonExample.json
+++ b/src/test/resources/JsonWithCommasInJsonExample.json
@@ -1,0 +1,75 @@
+{
+  "openapi" : "3.0.0",
+  "info" : {
+    "description" : "Sample API",
+    "title" : "Basic",
+    "version" : "1.0"
+  },
+  "tags" : [ {
+    "description" : "Basic tag",
+    "name" : "basic"
+  } ],
+  "paths" : {
+    "/ws" : {
+      "post" : {
+        "description" : "Create",
+        "operationId" : "ws-post",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "examples" : {
+                "basic" : {
+                  "$ref" : "#/components/examples/ex-1"
+                }
+              },
+              "schema" : {
+                "$ref" : "#/components/schemas/Item"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Item"
+                }
+              }
+            },
+            "description" : "Item created"
+          }
+        },
+        "summary" : "Create",
+        "tags" : [ "basic" ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "Item" : {
+        "description" : "",
+        "properties" : {
+          "id" : {
+            "description" : "Item id",
+            "type" : "integer"
+          },
+          "acceptHeader" : {
+            "type" : "string"
+          }
+        },
+        "title" : "item",
+        "type" : "object"
+      }
+    },
+    "examples": {
+      "ex-1": {
+        "summary" : "Example 1",
+        "value" : {
+          "id": 1,
+          "acceptHeader": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix #17 

PR to deal with values which includes commas (ie `"acceptHeader": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng"`)

The commas within quotes are ignored and the resulting JSON example is formatted correctly.