### PR TITLE
Set Tags as default Folder Strategy setting

### DIFF
--- a/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
@@ -23,7 +23,7 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
   protected String apiVersion = "1.0.0";
   // Select whether to create folders according to the spec’s paths or tags. Values: Paths | Tags
   public static final String FOLDER_STRATEGY = "folderStrategy";
-  public static final String FOLDER_STRATEGY_DEFAULT_VALUE = "Paths";
+  public static final String FOLDER_STRATEGY_DEFAULT_VALUE = "Tags";
   // Select whether to create Postman variables for path templates
   public static final String PATH_PARAMS_AS_VARIABLES = "pathParamsAsVariables";
   public static final Boolean PATH_PARAMS_AS_VARIABLES_DEFAULT_VALUE = true;

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -31,11 +31,11 @@ public class PostmanV2GeneratorTest {
     final PostmanV2Generator postmanV2Generator = new PostmanV2Generator();
     postmanV2Generator.processOpts();
 
-    Assert.assertEquals(postmanV2Generator.folderStrategy, "Paths");
+    Assert.assertEquals(postmanV2Generator.folderStrategy, "Tags");
     Assert.assertEquals(postmanV2Generator.postmanFile, "postman.json");
 
-    Assert.assertNotNull(postmanV2Generator.additionalProperties().get("codegenOperationsList"));
-    Assert.assertNull(postmanV2Generator.additionalProperties().get("codegenOperationsByTag"));
+    Assert.assertNull(postmanV2Generator.additionalProperties().get("codegenOperationsList"));
+    Assert.assertNotNull(postmanV2Generator.additionalProperties().get("codegenOperationsByTag"));
   }
   @Test
   public void testConfigWithFolderStrategyTags() throws Exception {


### PR DESCRIPTION
Makes sense to use `Tags` as default grouping of the Postman requests as it provides a better structure of the collection (all our examples and tests so far have used that)

@jlengrand 

