### PR TITLE
Create auto-generated variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ java -cp target/openapi-generator-postman-v2.jar:/openapi-generator/modules/open
 ## CONFIG OPTIONS
 These options may be applied as additional-properties (cli) or configOptions (plugins). 
 
-| Option | Description                                                                                                                                                                                 | Values          | Default      |
-| ------ |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|--------------|
-|folderStrategy| whether to create folders according to the spec’s paths or tags                                                                                                                             | Paths, Tags     | Paths        |
-|pathParamsAsVariables| boolean, whether to create Postman variables for path parameters                                                                                                                            | true, false     | true         |
-|postmanVariables| kebab-case list of Postman variables (i.e VAR1-VAR2-VAR3) to be created during the generation. Matching placeholders in request bodies will be defined as Postman variables                 |                 |       |
-|requestParameterGeneration| whether to generate the request parameters based on the schema or the examples                                                                                                              | Example, Schema | Example      |
+| Option                     | Description                                                                                                                                                                 | Values          | Default      |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|--------------|
+| folderStrategy             | whether to create folders according to the spec’s paths or tags                                                                                                             | Paths, Tags     | Paths        |
+| pathParamsAsVariables      | boolean, whether to create Postman variables for path parameters                                                                                                            | true, false     | true         |
+| postmanVariables           | kebab-case list of Postman variables (i.e VAR1-VAR2-VAR3) to be created during the generation. Matching placeholders in request bodies will be defined as Postman variables |                 |       |
+| generatedVariables         | kebab-case list of auto-generated variables (i.e VAR1-VAR2-VAR3). Matching placeholders in request bodies will be replaced with `{{$guid}}` Postman formula                 |                 |       |
+| requestParameterGeneration | whether to generate the request parameters based on the schema or the examples                                                                                              | Example, Schema | Example      |

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -424,4 +424,30 @@ public class PostmanV2GeneratorTest {
     TestUtils.assertFileContains(path, "(DEPRECATED)");
   }
 
+  @Test
+  public void testGeneratedVariables() throws IOException, ParseException {
+
+    File output = Files.createTempDirectory("postmantest_").toFile();
+    output.deleteOnExit();
+
+    final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("postman-v2")
+            .setInputSpec("./src/test/resources/BasicVariablesInExample.yaml")
+            .addAdditionalProperty(PostmanV2Generator.GENERATED_VARIABLES, "RANDOM_VALUE ")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+    final ClientOptInput clientOptInput = configurator.toClientOptInput();
+    DefaultGenerator generator = new DefaultGenerator();
+    List<File> files = generator.opts(clientOptInput).generate();
+
+    System.out.println(files);
+    files.forEach(File::deleteOnExit);
+
+    Path path = Paths.get(output + "/postman.json");
+    TestUtils.assertFileExists(path);
+
+    TestUtils.assertFileContains(path, "\\\"createDate\\\": \\\"{{$guid}}\\\"");
+
+  }
+
 }

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -400,5 +400,30 @@ public class PostmanV2GeneratorTest {
     TestUtils.assertFileContains(path, "\\\"acceptHeader\\\": \\\"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\\\"");
   }
 
+  @Test
+  public void testGeneratedVariables() throws IOException, ParseException {
+
+    File output = Files.createTempDirectory("postmantest_").toFile();
+    output.deleteOnExit();
+
+    final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("postman-v2")
+            .setInputSpec("./src/test/resources/BasicVariablesInExample.yaml")
+            .addAdditionalProperty(PostmanV2Generator.GENERATED_VARIABLES, "RANDOM_VALUE ")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+    final ClientOptInput clientOptInput = configurator.toClientOptInput();
+    DefaultGenerator generator = new DefaultGenerator();
+    List<File> files = generator.opts(clientOptInput).generate();
+
+    System.out.println(files);
+    files.forEach(File::deleteOnExit);
+
+    Path path = Paths.get(output + "/postman.json");
+    TestUtils.assertFileExists(path);
+
+    TestUtils.assertFileContains(path, "\\\"createDate\\\": \\\"{{$guid}}\\\"");
+
+  }
 
 }

--- a/src/test/resources/BasicVariablesInExample.yaml
+++ b/src/test/resources/BasicVariablesInExample.yaml
@@ -109,7 +109,7 @@ components:
         email: alotta.rotta@gmail.com
         dateOfBirth: '1997-10-31'
         emailVerified: true
-        createDate: '2019-08-24'
+        createDate: RANDOM_VALUE
 
 tags:
   - name: basic


### PR DESCRIPTION
Fix #24 

Add `generatedVariables` property to create Postman formulas (`{{$guid}}`) that generates unique values in the request bodies. Used the same approach as user-defined variables: list set during the OpenAPI-to-Postman generation

@jlengrand 