### PR TITLE
Deprecated endpoints

### DIFF
--- a/src/main/resources/postman-v2/item.mustache
+++ b/src/main/resources/postman-v2/item.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "{{path}}",
+    "name": "{{path}}{{#isDeprecated}} (DEPRECATED){{/isDeprecated}}",
                 "description": "{{notes}}",
                  "item": [
                         {{#vendorExtensions.postmanRequests}}

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -251,8 +251,9 @@ public class PostmanV2GeneratorTest {
             .setInputSpec("./src/test/resources/SampleProject.yaml")
             .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
+    final ClientOptInput clientOptInput = configurator.toClientOptInput();
     DefaultGenerator generator = new DefaultGenerator();
-    List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+    List<File> files = generator.opts(clientOptInput).generate();
 
     System.out.println(files);
     files.forEach(File::deleteOnExit);
@@ -400,5 +401,27 @@ public class PostmanV2GeneratorTest {
     TestUtils.assertFileContains(path, "\\\"acceptHeader\\\": \\\"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\\\"");
   }
 
+  @Test
+  public void testDeprecatedEndpoint() throws IOException, ParseException {
+
+    File output = Files.createTempDirectory("postmantest_").toFile();
+    output.deleteOnExit();
+
+    final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("postman-v2")
+            .setInputSpec("./src/test/resources/SampleProject.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+    DefaultGenerator generator = new DefaultGenerator();
+    List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+
+    System.out.println(files);
+    files.forEach(File::deleteOnExit);
+
+    Path path = Paths.get(output + "/postman.json");
+    TestUtils.assertFileExists(path);
+    // verify request name (from path)
+    TestUtils.assertFileContains(path, "(DEPRECATED)");
+  }
 
 }

--- a/src/test/resources/SampleProject.yaml
+++ b/src/test/resources/SampleProject.yaml
@@ -139,6 +139,7 @@ paths:
       description: Retrieve the information of the user with the matching user ID.
     patch:
       summary: Update User Information
+      deprecated: true
       operationId: patch-users-userId
       responses:
         '200':


### PR DESCRIPTION
Postman ignore the OpenAPI `deprecated` attribute. This PR add a post-fix (DEPRECATED) to make visible which endpoints are deprecated and should no longer be used