### PR TITLE
Create Postman variable if matching placeholder is found

### DIFF
--- a/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
@@ -368,13 +368,16 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
 
     for (String var : postmanVariableNames) {
       for(PostmanRequestItem requestItem : postmanRequests) {
-        requestItem.setBody(requestItem.getBody().replace(var, "{{" + var + "}}"));
-      }
+        if (requestItem.getBody().indexOf(var) > 0) {
 
-      variables.add(new PostmanVariable()
-              .addName(var)
-              .addType("string")
-              .addExample(""));
+          requestItem.setBody(requestItem.getBody().replace(var, "{{" + var + "}}"));
+
+          variables.add(new PostmanVariable()
+                  .addName(var)
+                  .addType("string")
+                  .addExample(""));
+        }
+      }
     }
 
     return postmanRequests;

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -190,6 +190,36 @@ public class PostmanV2GeneratorTest {
 
   }
   @Test
+  public void testVariableThatDoesNotExist() throws IOException, ParseException {
+
+    File output = Files.createTempDirectory("postmantest_").toFile();
+    output.deleteOnExit();
+
+    final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("postman-v2")
+            .setInputSpec("./src/test/resources/BasicVariablesInExample.yaml")
+            .addAdditionalProperty(PostmanV2Generator.POSTMAN_VARIABLES, "NOT_FOUND_VARIABLE")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+    final ClientOptInput clientOptInput = configurator.toClientOptInput();
+    DefaultGenerator generator = new DefaultGenerator();
+    List<File> files = generator.opts(clientOptInput).generate();
+
+    System.out.println(files);
+    files.forEach(File::deleteOnExit);
+
+    Path path = Paths.get(output + "/postman.json");
+    TestUtils.assertFileExists(path);
+
+    JSONObject jsonObject = (JSONObject) new JSONParser().parse(new FileReader(output + "/postman.json"));
+    // verify json has 2 variables only
+    assertTrue(jsonObject.get("variable") instanceof JSONArray);
+    assertEquals(2, ((JSONArray) jsonObject.get("variable")).size());
+
+    TestUtils.assertFileNotContains(path, "{{NOT_FOUND_VAR}}");
+
+  }
+  @Test
   public void testGenerateWithoutPathParamsVariables() throws IOException, ParseException {
 
     File output = Files.createTempDirectory("postmantest_").toFile();


### PR DESCRIPTION
PR to create Postman variables only when a matching placeholder is found in the OpenAPI examples

```
      .addAdditionalProperty(PostmanV2Generator.POSTMAN_VARIABLES, "VAR1-VAR2-VAR3")
```
will create 3 variables `VAR1, VAR2 and VAR3` only if the request examples include the matching placeholders