### PR TITLE
Define API Key as user variable

### DIFF
--- a/src/main/resources/postman-v2/postman.mustache
+++ b/src/main/resources/postman-v2/postman.mustache
@@ -57,7 +57,12 @@
 			"key": "baseUrl",
 			"value": "{{url}}",
 			"type": "string"
-		}{{/-first}}{{/servers}}{{#apiInfo}}{{#apis}}{{#vendorExtensions}}{{#-first}}{{#variables}}{{#-first}},{{/-first}}
+        }{{/-first}}{{/servers}}{{#authMethods}}{{#isApiKey}},
+        {
+            "key": "{{keyParamName}}",
+            "value": "",
+            "type": "string"
+        }{{/isApiKey}}{{/authMethods}}{{#apiInfo}}{{#apis}}{{#vendorExtensions}}{{#-first}}{{#variables}}{{#-first}},{{/-first}}
 		{
 	        {{! use first element in vendorExtensions }}
 			"key": "{{name}}",

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -156,7 +156,7 @@ public class PostmanV2GeneratorTest {
     JSONObject jsonObject = (JSONObject) new JSONParser().parse(new FileReader(output + "/postman.json"));
     // verify json has variables
     assertTrue(jsonObject.get("variable") instanceof JSONArray);
-    assertEquals(4, ((JSONArray) jsonObject.get("variable")).size());
+    assertEquals(5, ((JSONArray) jsonObject.get("variable")).size());
   }
 
   @Test
@@ -242,7 +242,7 @@ public class PostmanV2GeneratorTest {
     JSONObject jsonObject = (JSONObject) new JSONParser().parse(new FileReader(output + "/postman.json"));
     // verify json has only Server variables (baseUrl, etc..)
     assertTrue(jsonObject.get("variable") instanceof JSONArray);
-    assertEquals(3, ((JSONArray) jsonObject.get("variable")).size());
+    assertEquals(4, ((JSONArray) jsonObject.get("variable")).size());
   }
 
   @Test


### PR DESCRIPTION
When defined in OpenAPI spec add `API Key` as variable so it can be set by the user (at Collection or Environment level)