### PR TITLE
Prettify json examples

### DIFF
--- a/src/test/java/com/tweesky/cloudtools/codegen/ExampleJsonHelperTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/ExampleJsonHelperTest.java
@@ -52,7 +52,7 @@ public class ExampleJsonHelperTest {
     @Test
     public void formatJson() {
 
-        final String EXPECTED = "{\\n \\\"id\\\": 1,\\n \\\"city\\\": \\\"Amsterdam\\\"\\n}";
+        final String EXPECTED = "{\\n  \\\"id\\\" : 1,\\n  \\\"city\\\" : \\\"Amsterdam\\\"\\n}";
         final String JSON = "{\"id\":1,\"city\":\"Amsterdam\"}";
 
         assertEquals(EXPECTED, new ExampleJsonHelper().formatJson(JSON));
@@ -62,8 +62,18 @@ public class ExampleJsonHelperTest {
     @Test
     public void formatJsonIncludingCommas() {
 
-        final String EXPECTED = "{\\n \\\"id\\\": 1,\\n \\\"list\\\": \\\"AMS,LON,ROM\\\"\\n}";
+        final String EXPECTED = "{\\n  \\\"id\\\" : 1,\\n  \\\"list\\\" : \\\"AMS,LON,ROM\\\"\\n}";
         final String JSON = "{\"id\":1,\"list\":\"AMS,LON,ROM\"}";
+
+        assertEquals(EXPECTED, new ExampleJsonHelper().formatJson(JSON));
+
+    }
+
+    @Test
+    public void formatJsonWithUrl() {
+
+        final String EXPECTED = "{\\n  \\\"id\\\" : 1,\\n  \\\"url\\\" : \\\"https://github.com\\\"\\n}";
+        final String JSON = "{\"id\": 1,\"url\": \"https://github.com\"}";
 
         assertEquals(EXPECTED, new ExampleJsonHelper().formatJson(JSON));
 
@@ -80,7 +90,7 @@ public class ExampleJsonHelperTest {
     @Test
     public void convertObjectNodeToJson() {
 
-        final String EXPECTED = "{\\n \\\"id\\\": 1,\\n \\\"city\\\": \\\"Amsterdam\\\"\\n}";
+        final String EXPECTED = "{\\n  \\\"id\\\" : 1,\\n  \\\"city\\\" : \\\"Amsterdam\\\"\\n}";
 
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode city = mapper.createObjectNode();
@@ -95,7 +105,7 @@ public class ExampleJsonHelperTest {
     @Test
     public void convertObjectNodeIncludingDoubleQuoteToJson() {
 
-        final String EXPECTED = "{\\n \\\"id\\\": 1,\\n \\\"city\\\": \\\"it is \\\"Amsterdam\\\" \\\"\\n}";
+        final String EXPECTED = "{\\n  \\\"id\\\" : 1,\\n  \\\"city\\\" : \\\"it is \\\\\"Amsterdam\\\\\" \\\"\\n}";
 
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode city = mapper.createObjectNode();

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -268,7 +268,7 @@ public class PostmanV2GeneratorTest {
     TestUtils.assertFileExists(path);
     // verify response body comes from components/examples
     TestUtils.assertFileContains(path, "\"name\": \"Example request for Get User\"");
-    TestUtils.assertFileContains(path, "\"raw\": \"{\\n \\\"id\\\": 777,\\n \\\"firstName\\\": \\\"Alotta\\\",\\n \\\"lastName\\\": \\\"Rotta\\\",\\n ");
+    TestUtils.assertFileContains(path, "\"raw\": \"{\\n  \\\"id\\\" : 777,\\n  \\\"firstName\\\" : \\\"Alotta\\\",\\n  \\\"lastName\\\" : \\\"Rotta\\\",\\n ");
   }
 
   @Test
@@ -421,7 +421,7 @@ public class PostmanV2GeneratorTest {
     Path path = Paths.get(output + "/postman.json");
     TestUtils.assertFileExists(path);
     // check value with commas within quotes
-    TestUtils.assertFileContains(path, "\\\"acceptHeader\\\": \\\"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\\\"");
+    TestUtils.assertFileContains(path, "\\\"acceptHeader\\\" : \\\"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\\\"");
   }
 
   @Test
@@ -469,7 +469,7 @@ public class PostmanV2GeneratorTest {
     Path path = Paths.get(output + "/postman.json");
     TestUtils.assertFileExists(path);
 
-    TestUtils.assertFileContains(path, "\\\"createDate\\\": \\\"{{$guid}}\\\"");
+    TestUtils.assertFileContains(path, "\\\"createDate\\\" : \\\"{{$guid}}\\\"");
 
   }
 


### PR DESCRIPTION
JSON payloads are formatted but not following the standard JSON indentation and spacing.
This PR uses Jackson `pretty()` to format the JSON examples