### PR TITLE
Keep original header name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <openapi-generator-version>6.5.0-SNAPSHOT</openapi-generator-version>
+        <openapi-generator-version>6.5.0</openapi-generator-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.2</junit-version>
         <testng.version>7.7.1</testng.version>

--- a/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
@@ -204,6 +204,7 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
         // produces mediaType as `Accept` header (use first mediaType only)
         String mediaType = codegenOperation.produces.get(0).get("mediaType");
         CodegenParameter acceptHeader = new CodegenParameter();
+        acceptHeader.baseName = "Accept";
         acceptHeader.paramName = "Accept";
         CodegenProperty schema = new CodegenProperty();
         schema.defaultValue = mediaType;
@@ -215,6 +216,7 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
         // consumes mediaType as `Content-Type` header (use first mediaType only)
         String mediaType = codegenOperation.consumes.get(0).get("mediaType");
         CodegenParameter contentTypeHeader = new CodegenParameter();
+        contentTypeHeader.baseName = "Content-Type";
         contentTypeHeader.paramName = "Content-Type";
         CodegenProperty schema = new CodegenProperty();
         schema.defaultValue = mediaType;

--- a/src/main/resources/postman-v2/item.mustache
+++ b/src/main/resources/postman-v2/item.mustache
@@ -10,7 +10,7 @@
                                     "header": [
                                     {{#headerParams}}
                                         {
-                                            "key": "{{paramName}}",
+                                            "key": "{{baseName}}",
                                             "value": "{{schema.defaultValue}}"
                                         }{{^-last}},{{/-last}}
                                     {{/headerParams}}

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -347,6 +347,29 @@ public class PostmanV2GeneratorTest {
   }
 
   @Test
+  public void testHeaderParameter() throws IOException, ParseException {
+
+    File output = Files.createTempDirectory("postmantest_").toFile();
+    output.deleteOnExit();
+
+    final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("postman-v2")
+            .setInputSpec("./src/test/resources/SampleProject.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+    final ClientOptInput clientOptInput = configurator.toClientOptInput();
+    DefaultGenerator generator = new DefaultGenerator();
+    List<File> files = generator.opts(clientOptInput).generate();
+
+    files.forEach(File::deleteOnExit);
+
+    Path path = Paths.get(output + "/postman.json");
+    TestUtils.assertFileExists(path);
+    // check auth basic (1st security scheme in OpenAPI file)
+    TestUtils.assertFileContains(path, "\"Custom-Header\"");
+  }
+
+  @Test
   public void doubleCurlyBraces() {
     String str = "/api/{var}/archive";
 

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -347,7 +347,7 @@ public class PostmanV2GeneratorTest {
   }
 
   @Test
-  public void testHeaderParameter() throws IOException, ParseException {
+  public void testHeaderParameters() throws IOException, ParseException {
 
     File output = Files.createTempDirectory("postmantest_").toFile();
     output.deleteOnExit();
@@ -365,8 +365,9 @@ public class PostmanV2GeneratorTest {
 
     Path path = Paths.get(output + "/postman.json");
     TestUtils.assertFileExists(path);
-    // check auth basic (1st security scheme in OpenAPI file)
-    TestUtils.assertFileContains(path, "\"Custom-Header\"");
+    TestUtils.assertFileContains(path, "{ \"key\": \"Content-Type\", \"value\": \"application/json\"");
+    TestUtils.assertFileContains(path, "{ \"key\": \"Accept\", \"value\": \"application/json\"");
+    TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"null\"");
   }
 
   @Test

--- a/src/test/resources/SampleProject.yaml
+++ b/src/test/resources/SampleProject.yaml
@@ -51,6 +51,11 @@ paths:
           schema:
             type: string
             example: 888
+        - description: Custom HTTP header
+          name: Custom-Header
+          in: header
+          schema:
+            type: string
 
       responses:
         '200':


### PR DESCRIPTION
Retain the original header name (ie `Idempotency-Key`)