### PR TITLE
Fix header default value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <openapi-generator-version>6.5.0</openapi-generator-version>
+        <openapi-generator-version>7.0.0-SNAPSHOT</openapi-generator-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.2</junit-version>
         <testng.version>7.7.1</testng.version>

--- a/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
@@ -4,6 +4,7 @@ import com.tweesky.cloudtools.codegen.model.PostmanRequestItem;
 import com.tweesky.cloudtools.codegen.model.PostmanVariable;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.ServerVariable;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.model.*;
@@ -439,6 +440,24 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
   public String escapeUnsafeCharacters(String input) {
     //TODO: check that this logic is safe to escape unsafe characters to avoid code injection
     return input;
+  }
+
+  /**
+   * Return the default value of the property
+   * <p>
+   * Return null when the default is not defined
+   *
+   * @param schema Property schema
+   * @return string presentation of the default value of the property
+   */
+  @SuppressWarnings("static-method")
+  @Override
+  public String toDefaultValue(Schema schema) {
+    if (schema.getDefault() != null) {
+      return schema.getDefault().toString();
+    }
+
+    return null;
   }
 
   /**

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -367,7 +367,10 @@ public class PostmanV2GeneratorTest {
     TestUtils.assertFileExists(path);
     TestUtils.assertFileContains(path, "{ \"key\": \"Content-Type\", \"value\": \"application/json\"");
     TestUtils.assertFileContains(path, "{ \"key\": \"Accept\", \"value\": \"application/json\"");
-    TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"null\"");
+    // header without default value
+    TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"\"");
+    // header with default value
+    TestUtils.assertFileContains(path, "{ \"key\": \"Another-Custom-Header\", \"value\": \"abc\"");
   }
 
   @Test

--- a/src/test/resources/SampleProject.yaml
+++ b/src/test/resources/SampleProject.yaml
@@ -56,6 +56,12 @@ paths:
           in: header
           schema:
             type: string
+        - description: Custom HTTP header with default
+          name: Another-Custom-Header
+          in: header
+          schema:
+            type: string
+            default: abc
 
       responses:
         '200':


### PR DESCRIPTION
When a property has no default value the string `"null"` is used as default.

This PR overrides getPropertyDefaultValue to return `null` (instead of `"null"`)