### PR TITLE
Use parameter default value

### DIFF
--- a/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
@@ -12,8 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * OpenAPI generator for Postman format v2.1
@@ -121,7 +119,7 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
       variables.add(new PostmanVariable()
               .addName(parameter.paramName)
               .addType(mapToPostmanType(parameter.dataType))
-              .addExample(parameter.example));
+              .addDefaultValue(parameter.defaultValue));
     }
   }
 
@@ -138,7 +136,7 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
       variables.entrySet().stream().forEach(serverVariableEntry -> this.variables.add(new PostmanVariable()
               .addName(serverVariableEntry.getKey())
               .addType("string")
-              .addExample(serverVariableEntry.getValue().getDefault())));
+              .addDefaultValue(serverVariableEntry.getValue().getDefault())));
     }
 
     return super.fromServerVariables(variables);
@@ -390,7 +388,7 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
           variables.add(new PostmanVariable()
                   .addName(var)
                   .addType("string")
-                  .addExample(""));
+                  .addDefaultValue(""));
         }
       }
     }

--- a/src/main/java/com/tweesky/cloudtools/codegen/model/PostmanVariable.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/model/PostmanVariable.java
@@ -6,7 +6,7 @@ public class PostmanVariable {
 
     private String name;
     private String type;
-    private String example;
+    private String defaultValue;
 
     public PostmanVariable addName(String name) {
         this.name = name;
@@ -18,8 +18,8 @@ public class PostmanVariable {
         return this;
     }
 
-    public PostmanVariable addExample(String example) {
-        this.example = example;
+    public PostmanVariable addDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
         return this;
     }
 
@@ -39,12 +39,12 @@ public class PostmanVariable {
         this.type = type;
     }
 
-    public String getExample() {
-        return example;
+    public String getDefaultValue() {
+        return defaultValue;
     }
 
-    public void setExample(String example) {
-        this.example = example;
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
     }
 
     @Override
@@ -65,7 +65,7 @@ public class PostmanVariable {
         return "PostmanVariable{" +
                 "name='" + name + '\'' +
                 ", type='" + type + '\'' +
-                ", example='" + example + '\'' +
+                ", example='" + defaultValue + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/tweesky/cloudtools/codegen/model/PostmanVariable.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/model/PostmanVariable.java
@@ -65,7 +65,7 @@ public class PostmanVariable {
         return "PostmanVariable{" +
                 "name='" + name + '\'' +
                 ", type='" + type + '\'' +
-                ", example='" + defaultValue + '\'' +
+                ", defaultValue='" + defaultValue + '\'' +
                 '}';
     }
 }

--- a/src/main/resources/postman-v2/postman.mustache
+++ b/src/main/resources/postman-v2/postman.mustache
@@ -66,7 +66,7 @@
 		{
 	        {{! use first element in vendorExtensions }}
 			"key": "{{name}}",
-			"value": "{{example}}",
+			"value": "{{defaultValue}}",
 			"type": "{{type}}"
 		}{{^-last}},{{/-last}}{{/variables}}{{/-first}}{{/vendorExtensions}}{{/apis}}{{/apiInfo}}
 	]

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -152,12 +152,19 @@ public class PostmanV2GeneratorTest {
     System.out.println(files);
     files.forEach(File::deleteOnExit);
 
-    TestUtils.assertFileExists(Paths.get(output + "/postman.json"));
+    Path path = Paths.get(output + "/postman.json");
+    TestUtils.assertFileExists(path);
 
     JSONObject jsonObject = (JSONObject) new JSONParser().parse(new FileReader(output + "/postman.json"));
     // verify json has variables
     assertTrue(jsonObject.get("variable") instanceof JSONArray);
-    assertEquals(5, ((JSONArray) jsonObject.get("variable")).size());
+    assertEquals(6, ((JSONArray) jsonObject.get("variable")).size());
+    // verify param userId (without default value)
+    TestUtils.assertFileContains(path,
+            "key\": \"userId\", \"value\": \"\", \"type\": \"number\"");
+    // verify param groupId (with default value)
+    TestUtils.assertFileContains(path,
+            "key\": \"groupId\", \"value\": \"1\", \"type\": \"number\"");
   }
 
   @Test

--- a/src/test/resources/SampleProject.yaml
+++ b/src/test/resources/SampleProject.yaml
@@ -248,6 +248,31 @@ paths:
       description: Create a new user.
       tags:
         - basic
+  '/groups/{groupId}':
+    get:
+      summary: Get group by ID
+      tags:
+        - advanced
+      parameters:
+        - description: group Id
+          name: groupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            default: 1
+      responses:
+        '200':
+          description: Group Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '404':
+          description: Group Not Found
+      operationId: get-groups-groupId
+      description: Get group of users
+
 components:
   securitySchemes:
     BasicAuth:
@@ -307,6 +332,20 @@ components:
         - lastName
         - email
         - emailVerified
+    Group:
+      title: Grouo
+      type: object
+      description: ''
+      properties:
+        id:
+          type: integer
+          description: Unique identifier for the given group.
+        name:
+          type: string
+          example: admin
+      required:
+        - id
+        - name
   examples:
     get-user-basic:
       summary: Example request for Get User

--- a/src/test/resources/SampleProject.yaml
+++ b/src/test/resources/SampleProject.yaml
@@ -333,7 +333,7 @@ components:
         - email
         - emailVerified
     Group:
-      title: Grouo
+      title: Group
       type: object
       description: ''
       properties:


### PR DESCRIPTION
This PR makes sure the Postman collection uses the default value for a parameter as value for the corresponding Postman variable. When the parameter has no default value the variable will not have an initial value.