### PR TITLE
Disable request header without a value

### DIFF
--- a/src/main/resources/postman-v2/item.mustache
+++ b/src/main/resources/postman-v2/item.mustache
@@ -11,7 +11,8 @@
                                     {{#headerParams}}
                                         {
                                             "key": "{{baseName}}",
-                                            "value": "{{schema.defaultValue}}"
+                                            "value": "{{schema.defaultValue}}",
+                                            "disabled": {{#schema.defaultValue}}false{{/schema.defaultValue}}{{^schema.defaultValue}}true{{/schema.defaultValue}}
                                         }{{^-last}},{{/-last}}
                                     {{/headerParams}}
                                     ],

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -374,10 +374,10 @@ public class PostmanV2GeneratorTest {
     TestUtils.assertFileExists(path);
     TestUtils.assertFileContains(path, "{ \"key\": \"Content-Type\", \"value\": \"application/json\"");
     TestUtils.assertFileContains(path, "{ \"key\": \"Accept\", \"value\": \"application/json\"");
-    // header without default value
-    TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"\"");
-    // header with default value
-    TestUtils.assertFileContains(path, "{ \"key\": \"Another-Custom-Header\", \"value\": \"abc\"");
+    // header without default value (disabled: true)
+    TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"\", \"disabled\": true");
+    // header with default value (disabled: false)
+    TestUtils.assertFileContains(path, "{ \"key\": \"Another-Custom-Header\", \"value\": \"abc\", \"disabled\": false");
   }
 
   @Test


### PR DESCRIPTION
PR to disable the Postman request header when there it doesn't have a value. The request header is still created, but the user must enable it and provide a value.