### PR TITLE
Create variables only for exact match

### DIFF
--- a/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
@@ -12,6 +12,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * OpenAPI generator for Postman format v2.1
@@ -381,9 +383,16 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
 
     for (String var : postmanVariableNames) {
       for(PostmanRequestItem requestItem : postmanRequests) {
-        if (requestItem.getBody().indexOf(var) > 0) {
+        int index = requestItem.getBody().indexOf(var);
 
-          requestItem.setBody(requestItem.getBody().replace(var, "{{" + var + "}}"));
+        if (index > 0) {
+          // regex exact match of variable name (ie match MY_REF but not MY_REF_1)
+          String regex = "\\b" + var + "\\b(?!_\\d)";
+
+          Pattern pattern = Pattern.compile(regex);
+          Matcher matcher = pattern.matcher(requestItem.getBody());
+          // add curly-braces
+          requestItem.setBody(matcher.replaceAll("{{" + var + "}}"));
 
           variables.add(new PostmanVariable()
                   .addName(var)

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -194,7 +194,13 @@ public class PostmanV2GeneratorTest {
     assertTrue(jsonObject.get("variable") instanceof JSONArray);
     assertEquals(4, ((JSONArray) jsonObject.get("variable")).size());
 
+    // verify MY_VAR_NAME is marked as variable
     TestUtils.assertFileContains(path, "{{MY_VAR_NAME}}");
+
+    // verify MY_VAR_NAME_2 is found in the postman.json file
+    TestUtils.assertFileContains(path, "MY_VAR_NAME_2");
+    // verify MY_VAR_NAME_2 is not marked as variable
+    TestUtils.assertFileNotContains(path, "{{MY_VAR_NAME_2}}");
 
   }
   @Test

--- a/src/test/resources/BasicVariablesInExample.yaml
+++ b/src/test/resources/BasicVariablesInExample.yaml
@@ -32,6 +32,8 @@ paths:
             examples:
               patch-user:
                 $ref: '#/components/examples/patch-user-example'
+              patch-user-example-2:
+                $ref: '#/components/examples/patch-user-example-2'
             schema:
               $ref: '#/components/schemas/User'
       responses:
@@ -106,6 +108,16 @@ components:
         id: 001
         firstName: MY_VAR_NAME
         lastName: MY_VAR_LAST_NAME
+        email: alotta.rotta@gmail.com
+        dateOfBirth: '1997-10-31'
+        emailVerified: true
+        createDate: RANDOM_VALUE
+    patch-user-example-2:
+      summary: Example patch user
+      value:
+        id: 001
+        firstName: MY_VAR_NAME_2
+        lastName: Rotta
         email: alotta.rotta@gmail.com
         dateOfBirth: '1997-10-31'
         emailVerified: true


### PR DESCRIPTION
This PR improves the generation ensuring that Postman variables are created only when the name matches (exact, not substring) the variable name defined in the configuration (variable list).


