### PR TITLE
Change default configuration value

### DIFF
--- a/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
@@ -28,7 +28,7 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
   public static final String FOLDER_STRATEGY_DEFAULT_VALUE = "Tags";
   // Select whether to create Postman variables for path templates
   public static final String PATH_PARAMS_AS_VARIABLES = "pathParamsAsVariables";
-  public static final Boolean PATH_PARAMS_AS_VARIABLES_DEFAULT_VALUE = true;
+  public static final Boolean PATH_PARAMS_AS_VARIABLES_DEFAULT_VALUE = false;
   
   public static final String POSTMAN_FILE_DEFAULT_VALUE = "postman.json";
 

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -143,6 +143,7 @@ public class PostmanV2GeneratorTest {
     final CodegenConfigurator configurator = new CodegenConfigurator()
             .setGeneratorName("postman-v2")
             .setInputSpec("./src/test/resources/SampleProject.yaml")
+            .addAdditionalProperty(PostmanV2Generator.PATH_PARAMS_AS_VARIABLES, true)
             .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
     final ClientOptInput clientOptInput = configurator.toClientOptInput();
@@ -177,6 +178,7 @@ public class PostmanV2GeneratorTest {
             .setGeneratorName("postman-v2")
             .setInputSpec("./src/test/resources/BasicVariablesInExample.yaml")
             .addAdditionalProperty(PostmanV2Generator.POSTMAN_VARIABLES, "MY_VAR_NAME -MY_VAR_LAST_NAME ")
+            .addAdditionalProperty(PostmanV2Generator.PATH_PARAMS_AS_VARIABLES, true)
             .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
     final ClientOptInput clientOptInput = configurator.toClientOptInput();
@@ -213,6 +215,7 @@ public class PostmanV2GeneratorTest {
             .setGeneratorName("postman-v2")
             .setInputSpec("./src/test/resources/BasicVariablesInExample.yaml")
             .addAdditionalProperty(PostmanV2Generator.POSTMAN_VARIABLES, "NOT_FOUND_VARIABLE")
+            .addAdditionalProperty(PostmanV2Generator.PATH_PARAMS_AS_VARIABLES, true)
             .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
     final ClientOptInput clientOptInput = configurator.toClientOptInput();
@@ -241,7 +244,6 @@ public class PostmanV2GeneratorTest {
 
     final CodegenConfigurator configurator = new CodegenConfigurator()
             .setGeneratorName("postman-v2")
-            .addAdditionalProperty(PostmanV2Generator.PATH_PARAMS_AS_VARIABLES, false)
             .setInputSpec("./src/test/resources/SampleProject.yaml")
             .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
@@ -293,6 +295,7 @@ public class PostmanV2GeneratorTest {
     final CodegenConfigurator configurator = new CodegenConfigurator()
             .setGeneratorName("postman-v2")
             .setInputSpec("./src/test/resources/SampleProject.yaml")
+            .addAdditionalProperty(PostmanV2Generator.PATH_PARAMS_AS_VARIABLES, true)
             .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
     final ClientOptInput clientOptInput = configurator.toClientOptInput();


### PR DESCRIPTION
PR to change the default value for the configuration setting `pathParamsAsVariables`.

By default the generator shall ignore path parameters and skip the creation of the corresponding Postman variables.