### PR TITLE
Use Postman path param notation

### DIFF
--- a/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
@@ -193,7 +193,11 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
     for(CodegenOperation codegenOperation : opList) {
 
       if(pathParamsAsVariables) {
+        // create Postman variable from path parameter
         codegenOperation.path = doubleCurlyBraces(codegenOperation.path);
+      } else {
+        // use Postman notation for path parameter
+        codegenOperation.path = replacesBracesInPath(codegenOperation.path);
       }
 
       codegenOperation.summary = getSummary(codegenOperation);
@@ -475,6 +479,16 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
     String s = str.replace("{{", "{").replace("}}", "}");
     // change all singlebraces to doublebraces
     s = s.replace("{", "{{").replace("}", "}}");
+
+    return s;
+
+  }
+
+  // convert path from /users/{id} to /users/:id
+  String replacesBracesInPath(String path) {
+
+    String s = path.replace("{", ":");
+    s = s.replace("}", "");
 
     return s;
 

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -85,6 +85,8 @@ public class PostmanV2GeneratorTest {
 
     // verify request name (from summary)
     TestUtils.assertFileContains(path, "\"name\": \"Get User\"");
+    // verify request endpoint
+    TestUtils.assertFileContains(path, "\"name\": \"/users/:userId\"");
 
   }
 
@@ -166,6 +168,10 @@ public class PostmanV2GeneratorTest {
     // verify param groupId (with default value)
     TestUtils.assertFileContains(path,
             "key\": \"groupId\", \"value\": \"1\", \"type\": \"number\"");
+
+    // verify request endpoint
+    TestUtils.assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
+
   }
 
   @Test
@@ -197,6 +203,10 @@ public class PostmanV2GeneratorTest {
     assertEquals(4, ((JSONArray) jsonObject.get("variable")).size());
 
     TestUtils.assertFileContains(path, "{{MY_VAR_NAME}}");
+
+    // verify request endpoint
+    TestUtils.assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
+
 
   }
   @Test
@@ -253,6 +263,7 @@ public class PostmanV2GeneratorTest {
     // verify json has only Server variables (baseUrl, etc..)
     assertTrue(jsonObject.get("variable") instanceof JSONArray);
     assertEquals(4, ((JSONArray) jsonObject.get("variable")).size());
+
   }
 
   @Test


### PR DESCRIPTION
PR to make sure the endpoint URL`{{baseUrl}}/legalEntities/{id}` is converted to `{{baseUrl}}/legalEntities/:id`, using the Postman notation.
This allows to change the value in the "Params" tab without modifying the original URL.