### PR TITLE
Set path parameters values

### DIFF
--- a/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/PostmanV2Generator.java
@@ -192,25 +192,28 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
 
     for(CodegenOperation codegenOperation : opList) {
 
+      // use Postman notation for path parameter
+      codegenOperation.path = replacesBracesInPath(codegenOperation.path);
+
       if(pathParamsAsVariables) {
-        // create Postman variable from path parameter
-        codegenOperation.path = doubleCurlyBraces(codegenOperation.path);
-      } else {
-        // use Postman notation for path parameter
-        codegenOperation.path = replacesBracesInPath(codegenOperation.path);
-        // ad-hoc customisation for specific path parameters:
-        // companyId: set value as YOUR_COMPANY_ACCOUNT env variable
-        // merchantId: set value as YOUR_MERCHANT_ACCOUNT env variable
-        if(codegenOperation.path.contains(":companyId") || codegenOperation.path.contains(":merchantId")) {
-          for(CodegenParameter codegenParameter : codegenOperation.pathParams) {
-            if(codegenParameter.paramName.equalsIgnoreCase("companyId")) {
-              // set default value for `companyId` path parameter
-              codegenParameter.defaultValue = "{{YOUR_COMPANY_ACCOUNT}}";
-            }
-            if(codegenParameter.paramName.equalsIgnoreCase("merchantId")) {
-              // set default value for `merchantId` path parameter
-              codegenParameter.defaultValue = "{{YOUR_MERCHANT_ACCOUNT}}";
-            }
+        // set value of path parameter with corresponding env variable
+        for(CodegenParameter codegenParameter : codegenOperation.pathParams) {
+          codegenParameter.defaultValue = "{{" + codegenParameter.paramName + "}}";
+        }
+      }
+
+      // ad-hoc customisation for specific path parameters:
+      // companyId: set value as YOUR_COMPANY_ACCOUNT env variable
+      // merchantId: set value as YOUR_MERCHANT_ACCOUNT env variable
+      if(codegenOperation.path.contains(":companyId") || codegenOperation.path.contains(":merchantId")) {
+        for(CodegenParameter codegenParameter : codegenOperation.pathParams) {
+          if(codegenParameter.paramName.equalsIgnoreCase("companyId")) {
+            // set default value for `companyId` path parameter
+            codegenParameter.defaultValue = "{{YOUR_COMPANY_ACCOUNT}}";
+          }
+          if(codegenParameter.paramName.equalsIgnoreCase("merchantId")) {
+            // set default value for `merchantId` path parameter
+            codegenParameter.defaultValue = "{{YOUR_MERCHANT_ACCOUNT}}";
           }
         }
       }
@@ -494,17 +497,6 @@ public class PostmanV2Generator extends DefaultCodegen implements CodegenConfig 
   public String escapeQuotationMark(String input) {
     //TODO: check that this logic is safe to escape quotation mark to avoid code injection
     return input.replace("\"", "\\\"");
-  }
-
-  String doubleCurlyBraces(String str) {
-
-    // remove doublebraces first
-    String s = str.replace("{{", "{").replace("}}", "}");
-    // change all singlebraces to doublebraces
-    s = s.replace("{", "{{").replace("}", "}}");
-
-    return s;
-
   }
 
   // convert path from /users/{id} to /users/:id

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -173,7 +173,7 @@ public class PostmanV2GeneratorTest {
             "key\": \"groupId\", \"value\": \"1\", \"type\": \"number\"");
 
     // verify request endpoint
-    TestUtils.assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
+    TestUtils.assertFileContains(path, "\"name\": \"/users/:userId\"");
 
   }
 
@@ -208,7 +208,7 @@ public class PostmanV2GeneratorTest {
     TestUtils.assertFileContains(path, "{{MY_VAR_NAME}}");
 
     // verify request endpoint
-    TestUtils.assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
+    TestUtils.assertFileContains(path, "\"name\": \"/users/:userId\"");
 
   }
   @Test
@@ -315,7 +315,7 @@ public class PostmanV2GeneratorTest {
     Path path = Paths.get(output + "/postman.json");
     TestUtils.assertFileExists(path);
     // verify request name (from path)
-    TestUtils.assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
+    TestUtils.assertFileContains(path, "\"name\": \"/users/:userId\"");
   }
 
   @Test
@@ -394,20 +394,6 @@ public class PostmanV2GeneratorTest {
     TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"\", \"disabled\": true");
     // header with default value (disabled: false)
     TestUtils.assertFileContains(path, "{ \"key\": \"Another-Custom-Header\", \"value\": \"abc\", \"disabled\": false");
-  }
-
-  @Test
-  public void doubleCurlyBraces() {
-    String str = "/api/{var}/archive";
-
-    assertEquals("/api/{{var}}/archive", new PostmanV2Generator().doubleCurlyBraces(str));
-  }
-
-  @Test
-  public void doubleCurlyBracesNoChanges() {
-    String str = "/api/{{var}}/archive";
-
-    assertEquals("/api/{{var}}/archive", new PostmanV2Generator().doubleCurlyBraces(str));
   }
 
   @Test


### PR DESCRIPTION
Adopt Postman notation for setting values of path parameters (i.e. setting the parameter value instead of changing the URL)