### PR TITLE
Enable required parameters only

### DIFF
--- a/src/main/resources/postman-v2/item.mustache
+++ b/src/main/resources/postman-v2/item.mustache
@@ -48,7 +48,8 @@
                                             {{#queryParams}}
                                             {
                                                 "key": "{{paramName}}",
-                                                "value": "{{example}}"
+                                                "value": "{{example}}",
+                                                "disabled": {{#required}}false{{/required}}{{^required}}true{{/required}}
                                             }{{^-last}},{{/-last}}
                                             {{/queryParams}}
                                         ]

--- a/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/PostmanV2GeneratorTest.java
@@ -621,4 +621,29 @@ public class PostmanV2GeneratorTest {
             "key\": \"storeId\", \"value\": \"\",");
   }
 
+  @Test
+  public void testRequiredQueryParameter() throws IOException, ParseException {
+
+    File output = Files.createTempDirectory("postmantest_").toFile();
+    output.deleteOnExit();
+
+    final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("postman-v2")
+            .setInputSpec("./src/test/resources/SampleProject.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+    DefaultGenerator generator = new DefaultGenerator();
+    List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+
+    System.out.println(files);
+    files.forEach(File::deleteOnExit);
+
+    Path path = Paths.get(output + "/postman.json");
+    TestUtils.assertFileExists(path);
+    // verify param pUserId is set as disabled=false
+    TestUtils.assertFileContains(path, "{ \"key\": \"pUserId\", \"value\": \"888\", \"disabled\": false");
+
+  }
+
+
 }


### PR DESCRIPTION
Enable only OpenAPI request parameters if they are required. All optional parameters will be displayed in Postman, but disabled by default (so the user can choose what to include in the request)